### PR TITLE
Avoid name clash in test file creation

### DIFF
--- a/src/util/ofile.rs
+++ b/src/util/ofile.rs
@@ -125,11 +125,10 @@ mod tests {
 
     #[test]
     fn removed() {
-        let pid = std::process::id();
-        let name = format!("/tmp/output-file.{}", pid);
-        let path = Path::new(&name);
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("output-file");
 
-        let file = OutputFile::create(path).unwrap();
+        let file = OutputFile::create(&path).unwrap();
         assert!(path.exists());
         assert!(path.is_file());
         drop(file);
@@ -138,11 +137,10 @@ mod tests {
 
     #[test]
     fn retained() {
-        let pid = std::process::id();
-        let name = format!("/tmp/output-file.{}", pid);
-        let path = Path::new(&name);
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("output-file");
 
-        let file = OutputFile::create(path).unwrap();
+        let file = OutputFile::create(&path).unwrap();
         assert!(path.exists());
         assert!(path.is_file());
         drop(file.done());


### PR DESCRIPTION
Fixes: #2

Signed-off-by: Daiki Ueno <dueno@redhat.com>

<!-- 
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #123" or "Resolves enarx/repo-name#123", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
